### PR TITLE
Removed _configure_setattr and changed test structure

### DIFF
--- a/src/jdict/__init__.py
+++ b/src/jdict/__init__.py
@@ -102,23 +102,6 @@ def _configure_init(cls, fields: Tuple[_Field, ...]) -> callable:
     return ns[name]
 
 
-def _configure_setattr(fields: Tuple[_Field, ...]) -> callable:
-    """
-    Configure __setattr__ method for the subclass
-
-    :param fields: list of field descriptors
-    :return: function performing correct setting for mutable attributes only
-    """
-    mutable_attributes = {f.name for f in fields if not f.is_final}
-
-    def _protected_setattr(self, key: str, value: Any) -> None:
-        if key not in mutable_attributes:
-            raise AttributeError(f"{key} is final or does not exist")
-        self.__setitem__(key, value)
-
-    return _protected_setattr
-
-
 # noinspection PyPep8Naming
 class jdict(dict):
     """
@@ -140,7 +123,6 @@ class jdict(dict):
             raise ValueError("Empty field list")
         fields = tuple(_Field.get_field(n, t) for n, t in hints.items())
         setattr(cls, "__init__", _configure_init(cls, fields))
-        setattr(cls, "__setattr__", _configure_setattr(fields))
 
     def __getattr__(self, name: str) -> Any:
         """

--- a/test/unit/test_typed_jdict.py
+++ b/test/unit/test_typed_jdict.py
@@ -12,8 +12,10 @@ class Point2D(jdict):
 
 
 class TestTypedJdict(TestCase):
-    def setUp(self):
+    @classmethod
+    def setUpClass(cls):
         set_codec(json)
+        cls.point = Point2D(x=10, y=25, label="first point")
 
     def _validate_point(self, p) -> None:
         self.assertEqual(10, p.x)
@@ -25,7 +27,7 @@ class TestTypedJdict(TestCase):
             self.assertEqual("first point", p.label)
 
     def test_normal_initialization(self):
-        self._validate_point(Point2D(x=10, y=25, label="first point"))
+        self._validate_point(self.point)
 
     def test_no_optional_initialization(self):
         self._validate_point(Point2D(x=10, y=25))
@@ -40,9 +42,8 @@ class TestTypedJdict(TestCase):
         )  # PyCharm will not complain, but it fails in run-time
 
     def test_update_existing(self):
-        p = Point2D(x=10, y=25, label="first point")
-        p.y = 45
-        self.assertEqual(45, p.y)
+        self.point.y = 45
+        self.assertEqual(45, self.point.y)
 
     def test_update_optional(self):
         p = Point2D(x=10, y=25)
@@ -50,14 +51,12 @@ class TestTypedJdict(TestCase):
         self.assertEqual("missing label", p.label)
 
     def test_update_final(self):
-        p = Point2D(x=10, y=25, label="first point")
-        with self.assertRaises(AttributeError) as ae:
-            p.x = 45  # PyCharm complains and it fill fail
+        self.point.x = 45  # static type checkers and linters will complain about Final
+        self.assertEqual(45, self.point.x)
 
     def test_set_non_existent(self):
-        p = Point2D(x=10, y=25, label="first point")
-        with self.assertRaises(AttributeError) as ae:
-            p.z = 45  # PyCharm does not complain but it fill fail
+        self.point.z = 45
+        self.assertEqual(45, self.point.z)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Change Summary

## Description

Removed _configure_setattr functionality as we do not need to tweak Final type or non-existing key.
Instead if somebody wants to change Final, let the static type checkers and linters to catch it.


Fixes #10

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

